### PR TITLE
fix: クライアント側には一般的なエラーメッセージのみ返すように修正

### DIFF
--- a/apps/backend/internal/handlers/store.go
+++ b/apps/backend/internal/handlers/store.go
@@ -17,13 +17,14 @@ import (
 
 // GET /api/stores
 func GetStores(c echo.Context) error {
-	db := c.Get("db").(*gorm.DB)
-	var stores []domain.Store
+    db := c.Get("db").(*gorm.DB)
+    var stores []domain.Store
 
-	if err := db.Order("created_at desc").Find(&stores).Error; err != nil {
-		return c.JSON(http.StatusInternalServerError, echo.Map{"error": err.Error()})
-	}
-	return c.JSON(http.StatusOK, stores)
+    if err := db.Order("created_at desc").Find(&stores).Error; err != nil {
+        c.Logger().Errorf("failed to fetch stores: %v", err)
+        return c.JSON(http.StatusInternalServerError, echo.Map{"error": "internal server error"})
+    }
+    return c.JSON(http.StatusOK, stores)
 }
 
 // GET /api/stores/:id


### PR DESCRIPTION
# Pull Request Description

## 変更概要

内部DBのエラーメッセージの露出を修正。

## 変更箇所の説明

クライアント側に一般的なエラーメッセージのみを返すように修正。

## 変更目的

エラーメッセージが露出されていたため、セキュリティ面で不安だったため。

## レビュワーへの特記事項

コード全く分からないので前後関係どうなるか分かってないです。

## 関連Issue

関連するIssueがあればリンクを記載してください

## 動作確認

- 実施した動作確認の手順を記載してください
- 必要であれば画面キャプチャを貼り付けてください

## チェックリスト

- [ ] リンターを通したか
- [ ] Docsを更新したか
