### PR TITLE
検索画面でメニュー名による検索機能を追加

### DIFF
--- a/apps/mobile/features/search/screens/SearchScreen.tsx
+++ b/apps/mobile/features/search/screens/SearchScreen.tsx
@@ -39,10 +39,11 @@ export default function SearchScreen() {
       const matchesTags = shop.tags.some(tag => tag.toLowerCase().includes(query));
       const matchesDesc = shop.description.toLowerCase().includes(query);
       const matchesCategory = shop.category.toLowerCase().includes(query);
+      const matchesMenu = shop.menu?.some(item => item.name.toLowerCase().includes(query)) ?? false;
 
       if (matchesName) {
         shopNameResults.push(shop);
-      } else if (matchesTags || matchesDesc || matchesCategory) {
+      } else if (matchesTags || matchesDesc || matchesCategory || matchesMenu) {
         tagResults.push(shop);
       }
     });


### PR DESCRIPTION
# Pull Request Description

## 変更概要

検索画面でメニューによる検索機能を追加しました。

## 変更箇所の説明

apps/mobile/features/search/screens/SearchScreen.tsx

## 変更目的

なぜこの変更が必要か、背景や目的を記載してください

## レビュワーへの特記事項

今回の変更では、ホーム画面の検索欄には手を加えていません。
ホーム画面の検索機能は削除予定のため、検索画面のみに実装しています。

## 関連Issue

[#128](https://github.com/TeamH04/team-production/issues/128)

## 動作確認

- 実施した動作確認の手順を記載してください
  iOS 26.1で動作確認済み

- 必要であれば画面キャプチャを貼り付けてください
<img width="429" height="474" alt="image" src="https://github.com/user-attachments/assets/7f1af3e0-5c3a-401b-be6d-c4f92596792e" />
<img width="427" height="465" alt="image" src="https://github.com/user-attachments/assets/8d4e3479-a497-447f-a309-df797323224b" />




## チェックリスト

- [ ] リンターを通したか
- [ ] Docsを更新したか
