### PR TITLE
プロフィール編集画面などの「戻る」ボタンを他のものと統一

### DIFF
--- a/apps/mobile/app/profile/_layout.tsx
+++ b/apps/mobile/app/profile/_layout.tsx
@@ -8,6 +8,7 @@ export default function ProfileStackLayout() {
         options={{
           title: 'プロフィール編集',
           headerShown: false,
+          presentation: 'modal',
         }}
       />
     </Stack>

--- a/apps/mobile/components/BackButton.tsx
+++ b/apps/mobile/components/BackButton.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { Pressable, StyleProp, StyleSheet, Text, ViewStyle } from 'react-native';
+
+import { palette } from '@/constants/palette';
+
+type Props = {
+  onPress?: () => void;
+  label?: string;
+  style?: StyleProp<ViewStyle>;
+};
+
+export function BackButton({ onPress, label = '戻る', style }: Props) {
+  return (
+    <Pressable onPress={onPress} style={[styles.container, style]}>
+      <Text style={styles.icon}>＜</Text>
+      <Text style={styles.text}>{label}</Text>
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    alignItems: 'center',
+    backgroundColor: palette.secondarySurface,
+    borderRadius: 20,
+    flexDirection: 'row',
+    paddingHorizontal: 14,
+    paddingVertical: 8,
+  },
+  icon: {
+    color: palette.primary,
+    fontSize: 20,
+    fontWeight: '700',
+    marginRight: 4,
+  },
+  text: {
+    color: palette.primary,
+    fontSize: 14,
+    fontWeight: '600',
+  },
+});

--- a/apps/mobile/features/mypage/screens/MyPageScreen.tsx
+++ b/apps/mobile/features/mypage/screens/MyPageScreen.tsx
@@ -13,6 +13,7 @@ import {
 
 import Ionicons from '@expo/vector-icons/Ionicons';
 
+import { BackButton } from '@/components/BackButton';
 import { palette } from '@/constants/palette';
 import { TAB_BAR_SPACING } from '@/constants/TabBarSpacing';
 import { useReviews } from '@/features/reviews/ReviewsContext';
@@ -174,10 +175,7 @@ export default function MyPageScreen({
         >
           {/* いいねしたレビューヘッダー */}
           <View style={styles.headerContainer}>
-            <Pressable onPress={handleBackPress} style={styles.backButtonContainer}>
-              <Text style={styles.backButtonLabel}>＜</Text>
-              <Text style={styles.backButtonText}>戻る</Text>
-            </Pressable>
+            <BackButton onPress={handleBackPress} />
             <Text style={styles.headerTitle}>いいねしたレビュー</Text>
             <View style={styles.spacer} />
           </View>
@@ -247,10 +245,7 @@ export default function MyPageScreen({
         >
           {/* レビュー履歴ヘッダー */}
           <View style={styles.headerContainer}>
-            <Pressable onPress={handleBackPress} style={styles.backButtonContainer}>
-              <Text style={styles.backButtonLabel}>＜</Text>
-              <Text style={styles.backButtonText}>戻る</Text>
-            </Pressable>
+            <BackButton onPress={handleBackPress} />
             <Text style={styles.headerTitle}>レビュー履歴</Text>
             <View style={styles.spacer} />
           </View>
@@ -320,10 +315,7 @@ export default function MyPageScreen({
         >
           {/* お知らせヘッダー */}
           <View style={styles.headerContainer}>
-            <Pressable onPress={handleBackPress} style={styles.backButtonContainer}>
-              <Text style={styles.backButtonLabel}>＜</Text>
-              <Text style={styles.backButtonText}>戻る</Text>
-            </Pressable>
+            <BackButton onPress={handleBackPress} />
             <Text style={styles.headerTitle}>お知らせ</Text>
             <View style={styles.spacer} />
           </View>
@@ -347,10 +339,7 @@ export default function MyPageScreen({
         >
           {/* プロフィール編集ヘッダー */}
           <View style={styles.headerContainer}>
-            <Pressable onPress={handleBackPress} style={styles.backButtonContainer}>
-              <Text style={styles.backButtonLabel}>＜</Text>
-              <Text style={styles.backButtonText}>戻る</Text>
-            </Pressable>
+            <BackButton onPress={handleBackPress} />
             <Text style={styles.headerTitle}>プロフィール編集</Text>
             <View style={styles.spacer} />
           </View>
@@ -423,10 +412,7 @@ export default function MyPageScreen({
         >
           {/* 設定ヘッダー */}
           <View style={styles.headerContainer}>
-            <Pressable onPress={handleBackPress} style={styles.backButtonContainer}>
-              <Text style={styles.backButtonLabel}>＜</Text>
-              <Text style={styles.backButtonText}>戻る</Text>
-            </Pressable>
+            <BackButton onPress={handleBackPress} />
             <Text style={styles.headerTitle}>設定</Text>
             <View style={styles.spacer} />
           </View>
@@ -618,25 +604,6 @@ const styles = StyleSheet.create({
   },
   avatarLargeText: { color: palette.primary, fontSize: 32, fontWeight: '800' },
   avatarText: { color: palette.avatarText, fontSize: 22, fontWeight: '800' },
-  backButtonContainer: {
-    alignItems: 'center',
-    backgroundColor: palette.secondarySurface,
-    borderRadius: 20,
-    flexDirection: 'row',
-    paddingHorizontal: 14,
-    paddingVertical: 8,
-  },
-  backButtonLabel: {
-    color: palette.primary,
-    fontSize: 20,
-    fontWeight: '700',
-    marginRight: 4,
-  },
-  backButtonText: {
-    color: palette.primary,
-    fontSize: 14,
-    fontWeight: '600',
-  },
   card: { backgroundColor: palette.surface, borderRadius: 20, padding: 12 },
   cardShadow: {
     elevation: 4,


### PR DESCRIPTION
<!-- GitHub Copilot コードレビューへの指示: このプルリクエストをレビューしてコメントする際には日本語でお願いします。 -->

<!-- I want to review in Japanese. -->

# Pull Request Description

## 変更内容
プロフィールを編集、レビュー履歴などの「戻る」のボタンを他の画面のものと同じにしました
ただ、「Kuguri」のロゴをそのままにしているので思ってたのと違う場合は言ってほしいです

## 変更箇所の説明
apps/mobile/app/profile/_layout.tsx
apps/mobile/features/mypage/screens/MyPageScreen.tsx

## 変更目的

## 関連Issue
#205

## 動作確認
iOS26.2で動作確認済み

### before
<img width="866" height="342" alt="image" src="https://github.com/user-attachments/assets/796b5089-55f5-4783-86e8-328df7297a16" />

### after
<img width="512" height="248" alt="image" src="https://github.com/user-attachments/assets/8a39f21b-d778-422e-a032-d3081ba895e8" />

## チェックリスト

- [ ] リンターを通したか
- [ ] Docsを更新したか

## 特にレビューしてほしいところ

<!-- for GitHub Copilot review rule -->
<!--
レビューする際には、以下のprefix(接頭辞)をつけてください
[must]
[imo] (in my opinion)
[nits](nitpick)
[ask]
[fyi]
-->

<!--
以下の観点を見てください。
- docsディレクトリに書かれている方針に背いている場合は厳しめにレビューしてください
- 多重にネストした制御構文が含まれない。
- テストカバレッジを維持している。
- 変数名や関数名にスペルミスがなく、冗長な表現がない。
- 関数、型にJSDocが書かれており、十分な可読性を持っている。
- 関数やコンポーネントが再利用されており、重複した実装をしていない。
- 単一責任の原則(SRP)にしたがって、変更理由の異なるコードを共通化していない。
- baseブランチを間違っていない。
- CDKの実装変更を伴う場合、料金の差分が発生するかどうか
- console.logが残ってしまっていないか
- 複雑なロジックにテストが書かれているか
-->

<!-- for GitHub Copilot review  rule-->

<!-- I want to review in Japanese. -->
